### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,17 +14,17 @@ EventPinState	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-update  KEYWORD2
-schedule    KEYWORD2
-every   KEYWORD2
-once    KEYWORD2
-oscillate   KEYWORD2
+update	KEYWORD2
+schedule	KEYWORD2
+every	KEYWORD2
+once	KEYWORD2
+oscillate	KEYWORD2
 ledBlink	KEYWORD2
-pulse   KEYWORD2
+pulse	KEYWORD2
 addEvent	KEYWORD2
-removeEvent KEYWORD2
-removeAllEvents KEYWORD2
-hasEvent    KEYWORD2
+removeEvent	KEYWORD2
+removeAllEvents	KEYWORD2
+hasEvent	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -34,4 +34,4 @@ hasEvent    KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-INVALID_EVENT_ID    LITERAL1
+INVALID_EVENT_ID	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords